### PR TITLE
feat: enhance deployment script with secrets management and connection info generation

### DIFF
--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,11 @@
+# Deployment secrets and sensitive files
+*-secrets.txt
+*-connection-info.txt
+*.env
+*-compose.yml
+*-grafana.yml
+easy-install.log
+
+# Temporary files
+*.tmp
+*.log


### PR DESCRIPTION
This pull request enhances the deployment script by introducing secure handling of sensitive information and improving usability. Key changes include generating secure files for secrets and connection details, adding a new `show-secrets` command, and updating the `.gitignore` file to exclude sensitive and temporary files.

### Secure handling of sensitive information:
* [`deploy/deploy_mmp_local.sh`](diffhunk://#diff-3b695b204f56a53a208440baf6cee7733ea451c367d676ab349488287b62c084R98-R141): Added functionality to generate two files during deployment: a `*-secrets.txt` file for sensitive credentials and a `*-connection-info.txt` file for non-sensitive connection details. These files are created with appropriate permissions (`600` for secrets, `644` for connection info) to ensure security. [[1]](diffhunk://#diff-3b695b204f56a53a208440baf6cee7733ea451c367d676ab349488287b62c084R98-R141) [[2]](diffhunk://#diff-3b695b204f56a53a208440baf6cee7733ea451c367d676ab349488287b62c084L231-R337)
* [`deploy/deploy_mmp_local.sh`](diffhunk://#diff-3b695b204f56a53a208440baf6cee7733ea451c367d676ab349488287b62c084R166): Updated the cleanup process to remove the newly created secrets and connection info files.

### New command for accessing secrets:
* [`deploy/deploy_mmp_local.sh`](diffhunk://#diff-3b695b204f56a53a208440baf6cee7733ea451c367d676ab349488287b62c084R352): Added a `show-secrets` command to display deployment secrets in a secure manner. This command is integrated into the script's help section and command handling logic. [[1]](diffhunk://#diff-3b695b204f56a53a208440baf6cee7733ea451c367d676ab349488287b62c084R352) [[2]](diffhunk://#diff-3b695b204f56a53a208440baf6cee7733ea451c367d676ab349488287b62c084R362) [[3]](diffhunk://#diff-3b695b204f56a53a208440baf6cee7733ea451c367d676ab349488287b62c084R374) [[4]](diffhunk://#diff-3b695b204f56a53a208440baf6cee7733ea451c367d676ab349488287b62c084R407-R409)

### Exclusion of sensitive and temporary files:
* [`deploy/.gitignore`](diffhunk://#diff-1c2ed8007df124784c2d773c4a5333e6ea006e81ab4cad29ec592b4768ad8ca7R1-R11): Updated to exclude sensitive files (e.g., `*-secrets.txt`, `*.env`) and temporary files (e.g., `*.tmp`, `*.log`) from version control.